### PR TITLE
set _scenario on first run

### DIFF
--- a/remember-the-rhythm.py
+++ b/remember-the-rhythm.py
@@ -74,6 +74,7 @@ class RememberTheRhythm(GObject.Object, Peas.Activatable):
 
         print("DEBUG - load_complete")
         if not self.location:
+            self._scenario = 4
             self.first_run = True
             self._connect_signals()
             return


### PR DESCRIPTION
This was necessary to prevent _scenario not existing when tested elapsed_changed (if not elsewhere as well).